### PR TITLE
Update docker files to buster and the new Toolforge cluster naming

### DIFF
--- a/images/nbserve/Dockerfile
+++ b/images/nbserve/Dockerfile
@@ -1,10 +1,7 @@
-FROM docker-registry.tools.wmflabs.org/jessie-toollabs
-
-RUN echo lol
-RUN echo 'deb http://ftp.debian.org/debian jessie-backports main' >> /etc/apt/sources.list
+FROM docker-registry.tools.wmflabs.org/toolforge-buster-sssd
 
 RUN apt-get update
-RUN apt-get install --yes --no-install-recommends -t jessie-backports \
+RUN apt-get install --yes --no-install-recommends \
             nginx-extras \
             luarocks \
             unzip \

--- a/images/renderer/Dockerfile
+++ b/images/renderer/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-registry.tools.wmflabs.org/jessie-toollabs
+FROM docker-registry.tools.wmflabs.org/toolforge-buster-sssd
 
 RUN apt-get install --yes --no-install-recommends \
         python3 \


### PR DESCRIPTION
This is for deploy paws-public on the 2020 Kubernetes cluster and
since these images won't build anymore.

Please do not merge until after I've validated them in the cluster.