### PR TITLE
Update paws-public renderer dockerfile to buster and the new Toolforg…

### DIFF
--- a/images/renderer/Dockerfile
+++ b/images/renderer/Dockerfile
@@ -1,10 +1,12 @@
-FROM docker-registry.tools.wmflabs.org/jessie-toollabs
+FROM docker-registry.tools.wmflabs.org/toolforge-python37-sssd-web
 
-RUN apt-get install --yes --no-install-recommends \
-        python3 \
-        python3-pip \
-        uwsgi-plugin-python3 \
-        git
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install \
+    python3-pip \
+    python3-setuptools \
+    python3-wheel\
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install git+https://github.com/jupyter/nbconvert.git ipython werkzeug
 


### PR DESCRIPTION
This is for deploy paws-public on the 2020 Kubernetes cluster and
since this image won't build anymore.

This upgrades it to python 3.7 and Debian Buster as well.  The nbserve container cannot be as simply upgraded because of changes to the luarocks stuff.