### PR TITLE
nbserve: Use Buster base image

### DIFF
--- a/images/nbserve/Dockerfile
+++ b/images/nbserve/Dockerfile
@@ -1,14 +1,17 @@
-FROM docker-registry.tools.wmflabs.org/jessie-toollabs
+FROM docker-registry.tools.wmflabs.org/toolforge-buster-sssd
 
-RUN echo lol
-RUN echo 'deb http://ftp.debian.org/debian jessie-backports main' >> /etc/apt/sources.list
-
-RUN apt-get update
-RUN apt-get install --yes --no-install-recommends -t jessie-backports \
-            nginx-extras \
-            luarocks \
-            unzip \
-            build-essential
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+    && DEBIAN_FRONTEND=noninteractive \
+    apt-get install --yes --no-install-recommends \
+        build-essential \
+        libnginx-mod-http-lua \
+        luarocks \
+        nginx-extras \
+        python3 \
+        unzip \
+    && DEBIAN_FRONTEND=noninteractive apt-get autoremove --yes \
+    && DEBIAN_FRONTEND=noninteractive apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN luarocks install lua-resty-http
 RUN luarocks install lua-cjson
@@ -17,4 +20,4 @@ COPY nginx.py /srv/nginx.py
 
 EXPOSE 8080
 
-CMD /usr/bin/python /srv/nginx.py
+CMD ["/usr/bin/python3", "/srv/nginx.py"]

--- a/images/nbserve/nginx.py
+++ b/images/nbserve/nginx.py
@@ -1,8 +1,11 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 import os
 
 
 CONFIG = """
+# Load modules
+include /etc/nginx/modules-enabled/*.conf;
+
 # Let nginx automatically determine the number of worker processes
 # to run. This defaults to number of cores on the host.
 worker_processes auto;


### PR DESCRIPTION
* Use toolforge-buster-sssd base image
* Fix apt-get commands to use better practices for layer reuse
* Avoid unnecessary /bin/sh indirection for CMD
* Use python3 interpreter

Bug: T252217