### PR TITLE
Update pywikibot from stable branch

### DIFF
--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -130,7 +130,7 @@ jupyterhub:
     lifecycleHooks:
       postStart:
         exec:
-          command: ["sh", "-c", "cd /srv/paws/pwb && git fetch -t && git checkout stable || exit 0"]
+          command: ["sh", "-c", "cd /srv/paws/pwb && git pull "origin" stable || exit 0"]
     initContainers:
       - name: chown-userhome
         image: busybox

--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -130,7 +130,7 @@ jupyterhub:
     lifecycleHooks:
       postStart:
         exec:
-          command: ["sh", "-c", "cd /srv/paws/pwb && git pull "origin" stable || exit 0"]
+          command: ["sh", "-c", "cd /srv/paws/pwb && git pull origin stable || exit 0"]
     initContainers:
       - name: chown-userhome
         image: busybox


### PR DESCRIPTION
Current postStart hook gets to a depracated(?) `stable` tag in pywikibot.
The updated code is in the `stable` branch, using git pull should solve the
issues.

Bug T258142