### PR TITLE
emergency change: temporarily rolling back multiinstance proxy

### DIFF
--- a/paws/production.yaml
+++ b/paws/production.yaml
@@ -1,5 +1,10 @@
 mysql:
   domain: analytics.db.svc.eqiad.wmflabs
+  # TODO: remove this when the multiinstance replica proxy is removed
+  host: enwiki.analytics.db.svc.eqiad.wmflabs
+dbProxy: 
+  image:
+    tag: latest
 jupyterhub:
   hub:
     db:

--- a/paws/templates/db-proxy.yaml
+++ b/paws/templates/db-proxy.yaml
@@ -24,13 +24,15 @@ spec:
           {{- if .Values.mediawiki.enabled }}
           - {{ printf "--proxy-backend-addresses=%s-mariadb.%s:3306" .Release.Name .Release.Namespace | quote }}
           {{- else }}
-          {{- with .Values.mysql }}
-          {{- $sections := untilStep 1 9 1 | toStrings }}
-          {{- $domain := .domain }}
-          {{- range $sections }}
-          - {{ printf "--proxy-backend-addresses=s%s.%s:3306" . $domain | quote }}
-          {{- end }}
-          {{- end }}
+          - {{ printf "--proxy-backend-addresses=%s:3306" .Values.mysql.host | quote }}
+          # TODO: enable this part when the 8 IP addresses are actually different
+          # {{- with .Values.mysql }}
+          # {{- $sections := untilStep 1 9 1 | toStrings }}
+          # {{- $domain := .domain }}
+          # {{- range $sections }}
+          # - {{ printf "--proxy-backend-addresses=s%s.%s:3306" . $domain | quote }}
+          # {{- end }}
+          # {{- end }}
           {{- end }}
           - --proxy-address=0.0.0.0:3306
           - --proxy-skip-profiling
@@ -43,6 +45,8 @@ spec:
             value: {{ printf "s%s.%s" . $domain | quote }}
           {{- end }}
           {{- end }}
+          - name: MYSQL_HOST
+            value: {{ .Values.mysql.host | quote }}
           - name: MYSQL_USERNAME
             value: {{ .Values.mysql.username | quote }}
           - name: MYSQL_PASSWORD


### PR DESCRIPTION
Because the luaproxy interprets everything as the same IP (correctly),
the original version of the multiinstance changes won't work until they
are more than a bunch of records pointing to the same IP.

Rolling that back so that PAWS can still access the replicas until then.

Bug: T260389