### PR TITLE
paws-public: increase the timeout for read at the nginx proxy

### DIFF
--- a/images/nbserve/nginx.py
+++ b/images/nbserve/nginx.py
@@ -153,6 +153,9 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Original-URI $request_uri;
             proxy_set_header Host $host:$server_port;
+
+            # Some complex notebooks take a long time to render
+            proxy_read_timeout 180s;
         }
     }
 }


### PR DESCRIPTION
In some cases, notebooks can take a fair while for the renderer to
render. As is, the nbserve pod will just timeout and disconnect, causing
a 504.

Deployment of this in the current state will require manually building
the image, since we haven't re-established the deploy hook properly yet.

Bug: T270820