### PR TITLE
paws-public: expand the connect timeout on the nbserve process

### DIFF
--- a/images/nbserve/nginx.py
+++ b/images/nbserve/nginx.py
@@ -156,6 +156,7 @@ http {
 
             # Some complex notebooks take a long time to render
             proxy_read_timeout 180s;
+            proxy_connect_timeout 180s;
         }
     }
 }


### PR DESCRIPTION
Since the error I'm specifically trying to fix is something taking 150+
seconds to render, the read timeout should be fine. The connect timeout
might not be.

Bug: T270820