### PR TITLE
Multiinstance mysql

### DIFF
--- a/paws/production.yaml
+++ b/paws/production.yaml
@@ -1,3 +1,7 @@
+beta:
+  mysql:
+    enabled: true
+    domain: analytics.db.svc.wikimedia.cloud
 mysql:
   domain: analytics.db.svc.eqiad.wmflabs
   # TODO: remove this when the multiinstance replica proxy is removed

--- a/paws/templates/beta-db-proxy.yaml
+++ b/paws/templates/beta-db-proxy.yaml
@@ -63,7 +63,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: mysql
+  name: beta-mysql
 spec:
   ports:
   - port: 3306

--- a/paws/templates/beta-db-proxy.yaml
+++ b/paws/templates/beta-db-proxy.yaml
@@ -1,0 +1,74 @@
+{{ if .Values.beta.mysql.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: beta-db-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: beta-db-proxy
+  template:
+    metadata:
+      labels:
+        name: beta-db-proxy
+        app: beta-db-proxy
+    spec:
+      containers:
+      - name: beta-db-proxy
+        image: {{ tpl .Values.beta.dbProxy.image.template . | quote }}
+        imagePullPolicy: IfNotPresent
+        command:
+          - mysql-proxy
+          - --plugins=proxy
+          - --proxy-lua-script=/srv/auth.lua
+          {{- if .Values.mediawiki.enabled }}
+          - {{ printf "--proxy-backend-addresses=%s-mariadb.%s:3306" .Release.Name .Release.Namespace | quote }}
+          {{- else }}
+          {{- with .Values.beta.mysql }}
+          {{- $sections := untilStep 1 9 1 | toStrings }}
+          {{- $domain := .domain }}
+          {{- range $sections }}
+          - {{ printf "--proxy-backend-addresses=s%s.%s:3306" . $domain | quote }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          - --proxy-address=0.0.0.0:3306
+          - --proxy-skip-profiling
+        env:
+          {{- with .Values.beta.mysql }}
+          {{- $sections := untilStep 1 9 1 | toStrings }}
+          {{- $domain := .domain }}
+          {{- range $sections }}
+          - name: {{ printf "SEC%s_HOST" . | quote }}
+            value: {{ printf "s%s.%s" . $domain | quote }}
+          {{- end }}
+          {{- end }}
+          - name: MYSQL_HOST
+            value: {{ .Values.mysql.host | quote }}
+          - name: MYSQL_USERNAME
+            value: {{ .Values.mysql.username | quote }}
+          - name: MYSQL_PASSWORD
+            value: {{ .Values.mysql.password | quote }}
+          - name: HMAC_KEY
+            value: {{ .Values.dbProxy.hmacKey | quote }}
+          - name: MYSQL_DOMAIN
+            value: {{ .Values.beta.mysql.domain | quote }}
+        resources:
+{{ toYaml .Values.dbProxy.resources | indent 12 }}
+        ports:
+          - containerPort: 3306
+            name: mysql
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+spec:
+  ports:
+  - port: 3306
+    protocol: TCP
+    targetPort: 3306
+  selector:
+    name: beta-db-proxy
+{{ end }}

--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -183,6 +183,7 @@ jupyterhub:
                   ]
           
                   spawner.environment['MYSQL_HOST'] = os.environ['MYSQL_SERVICE_HOST']
+                  spawner.environment['BETA_MYSQL_HOST'] = os.environ['BETA_MYSQL_SERVICE_HOST']
                   mysql_password = hmac.new(
                       os.environ['MYSQL_HMAC_KEY'].encode('utf-8'),
                       identity['username'].encode('utf-8'),
@@ -247,6 +248,17 @@ mysql:
   domain: "svc.cluster.local"
   username: s52771
   password: "iAmNotSecret0"
+# beta is for live testing features not ready for production use
+beta:
+  mysql:
+    enabled: false
+    domain: "svc.cluster.local"
+  dbProxy:
+    image: 
+      name: quay.io/wikimedia-paws-prod/db-proxy
+      tag: multiinstance
+      # dbProxy.image.template safely defines image:tag name in yaml
+      template: "{{ .Values.dbProxy.image.name}}:{{.Values.dbProxy.image.tag }}"
 # If not deployed for prod use, we use the Bitnami mediawiki chart for testing
 mediawikiHacks:
   image:


### PR DESCRIPTION
These two commits **should** create a parallel mysql-proxy that talks to the multi-instance wiki replicas. Please check it. helm renders it fine at very least in both dev mode and production.

I cannot actually test it except in the cluster since this is something that only lives in the cloud. As long as I've caught any possible name clashes, it should have no impact on the existing services, though.