### PR TITLE
Setup OpenRefine on PAWS

### DIFF
--- a/images/singleuser/Dockerfile
+++ b/images/singleuser/Dockerfile
@@ -71,6 +71,24 @@ RUN apt-get install --yes \
         vim \
         mariadb-client > /dev/null
 
+
+# Needed by RStudio
+RUN apt-get update -qq --yes && \
+    apt-get install --yes --no-install-recommends -qq \
+        psmisc \
+        sudo \
+        libapparmor1 \
+        lsb-release \
+        libclang-dev  > /dev/null
+# Install RStudio
+# 1.3.959 is latest version that works with jupyter-rsession-proxy
+# See https://github.com/jupyterhub/jupyter-rsession-proxy/issues/93#issuecomment-725874693
+ENV RSTUDIO_URL https://download2.rstudio.org/server/bionic/amd64/rstudio-server-1.3.959-amd64.deb
+RUN curl --silent --location --fail ${RSTUDIO_URL} > /tmp/rstudio.deb && \
+    dpkg -i /tmp/rstudio.deb && \
+    rm /tmp/rstudio.deb
+
+
 # Machine-learning type stuff
 RUN apt-get install --yes \
     # For scipy & friends
@@ -102,6 +120,14 @@ RUN apt-get install --yes \
 ENV R_LIBS_USER /srv/r
 RUN install -d -o ${NB_USER} -g ${NB_USER} ${R_LIBS_USER}
 
+# R_LIBS_USER is set by default in /etc/R/Renviron, which RStudio loads.
+# We uncomment the default, and set what we wanna - so it picks up
+# the packages we install. Without this, RStudio doesn't see the packages
+# that R does.
+# Stolen from https://github.com/jupyterhub/repo2docker/blob/6a07a48b2df48168685bb0f993d2a12bd86e23bf/repo2docker/buildpacks/r.py
+RUN sed -i -e '/^R_LIBS_USER=/s/^/#/' /etc/R/Renviron && \
+    echo "R_LIBS_USER=${R_LIBS_USER}" >> /etc/R/Renviron
+
 # Create venv directory, and let users install into it
 ENV VENV_DIR /srv/paws
 RUN install -d -o ${NB_USER} -g ${NB_USER} ${VENV_DIR}
@@ -123,6 +149,9 @@ RUN python -m bash_kernel.install --sys-prefix
 
 # Set CRAN mirror to rspm before we install anything
 COPY Rprofile.site /usr/lib/R/etc/Rprofile.site
+# RStudio needs its own config
+COPY rsession.conf /etc/rstudio/rsession.conf
+
 
 # Install the R Kernel
 RUN r -e "install.packages('IRkernel', version='1.1.1')" && \

--- a/images/singleuser/Dockerfile
+++ b/images/singleuser/Dockerfile
@@ -57,6 +57,7 @@ RUN apt-get update --yes > /dev/null && \
         r-recommended \
         r-base-dev \
         r-cran-littler \
+        openjdk-11-jdk \
         nodejs > /dev/null
 
 # Utilities
@@ -88,6 +89,11 @@ RUN curl --silent --location --fail ${RSTUDIO_URL} > /tmp/rstudio.deb && \
     dpkg -i /tmp/rstudio.deb && \
     rm /tmp/rstudio.deb
 
+# Setup OpenRefine
+ENV OPENREFINE_DIR /srv/openrefine
+RUN mkdir -p ${OPENREFINE_DIR} && cd ${OPENREFINE_DIR} && \
+    curl -L https://github.com/OpenRefine/OpenRefine/releases/download/3.4.1/openrefine-linux-3.4.1.tar.gz | tar xzf - --strip=1
+COPY proxies/openrefine-logo.svg ${OPENREFINE_DIR}}/openrefine-logo.svg
 
 # Machine-learning type stuff
 RUN apt-get install --yes \
@@ -178,5 +184,8 @@ COPY banner /etc/bash.bashrc
 
 # use custom css to hide clusters tab
 COPY --chown=tools.paws:tools.paws hide_clusters_tab.css /home/paws/.jupyter/custom/custom.css
+
+# Setup custom config as needed
+COPY jupyter_notebook_config.py /srv/paws/etc/jupyter/jupyter_notebook_config.py
 
 EXPOSE 8888

--- a/images/singleuser/jupyter_notebook_config.py
+++ b/images/singleuser/jupyter_notebook_config.py
@@ -1,3 +1,5 @@
+# Disable flake8 for this file, since it's a config file not just python
+# flake8: noqa
 import os
 
 openrefine_path = os.path.join(os.environ['OPENREFINE_DIR'], 'refine')

--- a/images/singleuser/jupyter_notebook_config.py
+++ b/images/singleuser/jupyter_notebook_config.py
@@ -2,17 +2,25 @@
 # flake8: noqa
 import os
 
-openrefine_path = os.path.join(os.environ['OPENREFINE_DIR'], 'refine')
-openrefine_logo_path = os.path.join(os.environ['OPENREFINE_DIR'], 'openrefine-logo.svg')
+openrefine_path = os.path.join(os.environ["OPENREFINE_DIR"], "refine")
+openrefine_logo_path = os.path.join(
+    os.environ["OPENREFINE_DIR"], "openrefine-logo.svg"
+)
 c.ServerProxy.servers = {
-    'openrefine': {
-        'command': [openrefine_path, '-p', '{port}', '-d', os.path.expanduser('~')],
-        'port': 3333,
-        'timeout': 120,
-        'launcher_entry': {
-            'enabled': True,
-            'icon_path': openrefine_logo_path,
-            'title': 'OpenRefine',
+    "openrefine": {
+        "command": [
+            openrefine_path,
+            "-p",
+            "{port}",
+            "-d",
+            os.path.expanduser("~"),
+        ],
+        "port": 3333,
+        "timeout": 120,
+        "launcher_entry": {
+            "enabled": True,
+            "icon_path": openrefine_logo_path,
+            "title": "OpenRefine",
         },
     },
 }

--- a/images/singleuser/jupyter_notebook_config.py
+++ b/images/singleuser/jupyter_notebook_config.py
@@ -1,0 +1,16 @@
+import os
+
+openrefine_path = os.path.join(os.environ['OPENREFINE_DIR'], 'refine')
+openrefine_logo_path = os.path.join(os.environ['OPENREFINE_DIR'], 'openrefine-logo.svg')
+c.ServerProxy.servers = {
+    'openrefine': {
+        'command': [openrefine_path, '-p', '{port}', '-d', os.path.expanduser('~')],
+        'port': 3333,
+        'timeout': 120,
+        'launcher_entry': {
+            'enabled': True,
+            'icon_path': openrefine_logo_path,
+            'title': 'OpenRefine',
+        },
+    },
+}

--- a/images/singleuser/proxies/openrefine-logo.svg
+++ b/images/singleuser/proxies/openrefine-logo.svg
@@ -1,0 +1,605 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="630.94562"
+   height="590.83252"
+   id="svg4534"
+   version="1.1"
+   inkscape:version="0.47 r22583"
+   sodipodi:docname="google-refine-logo.svg">
+  <title
+     id="title5266">Google Refine logo</title>
+  <defs
+     id="defs4536">
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       id="perspective4542" />
+    <inkscape:perspective
+       id="perspective4552"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4318">
+      <path
+         d="m 0,1090.667 612,0 L 612,0 0,0 0,1090.667 z"
+         id="path4320" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4326">
+      <path
+         d="m 160.801,1054.46 272.189,0 0,-172.457 -272.189,0 0,172.457 z"
+         id="path4328" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4342">
+      <path
+         d="m 107.76,1036.47 158.893,0 0,-106.756 -158.893,0 0,106.756 z"
+         id="path4344" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4358">
+      <path
+         d="m 26.4375,1007.89 467.3225,0 0,-243.858 -467.3225,0 0,243.858 z"
+         id="path4360" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4374">
+      <path
+         d="m 273.938,774.952 210.147,0 0,-95.281 -210.147,0 0,95.281 z"
+         id="path4376" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4390">
+      <path
+         d="m 31.2983,985.162 48.3047,0 0,-198.637 -48.3047,0 0,198.637 z"
+         id="path4392" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4406">
+      <path
+         d="m 23.0552,1075.55 203.5398,0 0,-46.41 -203.5398,0 0,46.41 z"
+         id="path4408" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4422">
+      <path
+         d="m 279.427,923.682 149.953,0 0,-117.352 -149.953,0 0,117.352 z"
+         id="path4424" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4438">
+      <path
+         d="m 128.13,835.578 26.543,0 0,-105 -26.543,0 0,105 z"
+         id="path4440" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4454">
+      <path
+         d="m 213.16,781.584 78.444,0 0,-80.179 -78.444,0 0,80.179 z"
+         id="path4456" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4470">
+      <path
+         d="m 86.3154,908.898 294.9826,0 0,-289.725 -294.9826,0 0,289.725 z"
+         id="path4472" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4494">
+      <path
+         d="m 120.511,689.474 40.439,0 0,-73.733 -40.439,0 0,73.733 z"
+         id="path4496" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4514">
+      <path
+         d="m 415.58,953.875 92.88,0 0,-174.815 -92.88,0 0,174.815 z"
+         id="path4516" />
+    </clipPath>
+    <inkscape:perspective
+       id="perspective4901"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4318-1">
+      <path
+         d="m 0,1090.667 612,0 L 612,0 0,0 0,1090.667 z"
+         id="path4320-5" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4326-3">
+      <path
+         d="m 160.801,1054.46 272.189,0 0,-172.457 -272.189,0 0,172.457 z"
+         id="path4328-4" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4342-0">
+      <path
+         d="m 107.76,1036.47 158.893,0 0,-106.756 -158.893,0 0,106.756 z"
+         id="path4344-3" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4358-1">
+      <path
+         d="m 26.4375,1007.89 467.3225,0 0,-243.858 -467.3225,0 0,243.858 z"
+         id="path4360-7" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4374-9">
+      <path
+         d="m 273.938,774.952 210.147,0 0,-95.281 -210.147,0 0,95.281 z"
+         id="path4376-0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4390-3">
+      <path
+         d="m 31.2983,985.162 48.3047,0 0,-198.637 -48.3047,0 0,198.637 z"
+         id="path4392-5" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4406-2">
+      <path
+         d="m 23.0552,1075.55 203.5398,0 0,-46.41 -203.5398,0 0,46.41 z"
+         id="path4408-9" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4422-1">
+      <path
+         d="m 279.427,923.682 149.953,0 0,-117.352 -149.953,0 0,117.352 z"
+         id="path4424-2" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4438-6">
+      <path
+         d="m 128.13,835.578 26.543,0 0,-105 -26.543,0 0,105 z"
+         id="path4440-1" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4454-7">
+      <path
+         d="m 213.16,781.584 78.444,0 0,-80.179 -78.444,0 0,80.179 z"
+         id="path4456-0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4470-1">
+      <path
+         d="m 86.3154,908.898 294.9826,0 0,-289.725 -294.9826,0 0,289.725 z"
+         id="path4472-5" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4494-2">
+      <path
+         d="m 120.511,689.474 40.439,0 0,-73.733 -40.439,0 0,73.733 z"
+         id="path4496-2" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4514-9">
+      <path
+         d="m 415.58,953.875 92.88,0 0,-174.815 -92.88,0 0,174.815 z"
+         id="path4516-0" />
+    </clipPath>
+    <linearGradient
+       x1="0"
+       y1="0"
+       x2="1"
+       y2="0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-130.9263,-428.24127,-428.24127,130.9263,303.6875,1036.2104)"
+       spreadMethod="pad"
+       id="linearGradient4304">
+      <stop
+         style="stop-opacity:1;stop-color:#b1dfff"
+         offset="0"
+         id="stop4306" />
+      <stop
+         style="stop-opacity:1;stop-color:#0fabff"
+         offset="0.600006"
+         id="stop4308" />
+      <stop
+         style="stop-opacity:1;stop-color:#0089cc"
+         offset="1"
+         id="stop4310" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="49.849398"
+     inkscape:cy="349.40831"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1141"
+     inkscape:window-height="848"
+     inkscape:window-x="23"
+     inkscape:window-y="53"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata4539">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Google Refine logo</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Google Inc.</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <cc:license
+           rdf:resource="http://code.google.com/p/google-refine/source/browse/trunk/LICENSE.txt" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-75.955771,-319.80308)">
+    <g
+       transform="matrix(1.25,0,0,-1.25,59.256683,1676.1947)"
+       id="g4294">
+      <g
+         id="g4296">
+        <g
+           id="g4302">
+          <path
+             d="m 24.548,1010.156 c 0.596,-0.978 1.042,-1.477 1.042,-1.477 l 0,0 c 0,0 90.627,-382.257 97.767,-385.582 l 0,0 c 9.132,-4.254 103.874,33.179 193.744,70.611 l 0,0 c 90.085,37.522 175.273,75.045 164.43,70.581 l 0,0 13.781,10.037 1.501,1.462 c 22.942,13.862 9.043,56.704 9.043,56.704 l 0,0 -97.422,130.221 -175.825,95.228 -172.047,17.85 c -48.803,-36.498 -39.627,-59.748 -36.014,-65.635"
+             style="fill:url(#linearGradient4304);stroke:none"
+             id="path4312" />
+        </g>
+      </g>
+    </g>
+    <g
+       transform="matrix(1.25,0,0,-1.25,59.256683,1676.1947)"
+       id="g4314">
+      <g
+         id="g4316"
+         clip-path="url(#clipPath4318-1)">
+        <g
+           id="g4322">
+          <g
+             id="g4324" />
+          <g
+             id="g4330">
+            <g
+               style="opacity:0.75"
+               clip-path="url(#clipPath4326-3)"
+               id="g4332">
+              <g
+                 transform="translate(236.0601,1054.4551)"
+                 id="g4334">
+                <path
+                   d="M 0,0 -75.259,-11.844 40.272,-118.142 196.93,-172.452 171.162,-90.884 0,0 z"
+                   style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                   id="path4336" />
+              </g>
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4338">
+          <g
+             id="g4340" />
+          <g
+             id="g4346">
+            <g
+               style="opacity:0.75"
+               clip-path="url(#clipPath4342-0)"
+               id="g4348">
+              <g
+                 transform="translate(151.9956,1036.4688)"
+                 id="g4350">
+                <path
+                   d="M 0,0 -44.236,-86.497 114.657,-106.755 0,0 z"
+                   style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                   id="path4352" />
+              </g>
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4354">
+          <g
+             id="g4356" />
+          <g
+             id="g4362">
+            <g
+               style="opacity:0.78999299"
+               clip-path="url(#clipPath4358-1)"
+               id="g4364">
+              <g
+                 transform="translate(493.7598,776.0391)"
+                 id="g4366">
+                <path
+                   d="m 0,0 c 0,0 -163.448,22.99 -246.38,67.796 -82.926,44.812 -103.032,60.428 -220.942,164.057 l 5.9,-24.781 c 0,0 106.193,-105.01 183.766,-142.429 77.575,-37.42 185.151,-66.636 266.149,-76.65 L 0,0 z"
+                   style="fill:#b5def6;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                   id="path4368" />
+              </g>
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4370">
+          <g
+             id="g4372" />
+          <g
+             id="g4378">
+            <g
+               style="opacity:0.60000598"
+               clip-path="url(#clipPath4374-9)"
+               id="g4380">
+              <g
+                 transform="translate(427.8623,774.9521)"
+                 id="g4382">
+                <path
+                   d="M 0,0 C 9.036,-0.769 8.354,-1.114 56.223,-10.354 L -153.924,-95.281 0,0 z"
+                   style="fill:#b5def6;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                   id="path4384" />
+              </g>
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4386">
+          <g
+             id="g4388" />
+          <g
+             id="g4394">
+            <g
+               style="opacity:0.60000598"
+               clip-path="url(#clipPath4390-3)"
+               id="g4396">
+              <g
+                 transform="translate(72.0361,948.4395)"
+                 id="g4398">
+                <path
+                   d="M 0,0 C -2.839,5.854 -40.738,36.722 -40.738,36.722 L 7.567,-161.914"
+                   style="fill:#b5def6;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                   id="path4400" />
+              </g>
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4402">
+          <g
+             id="g4404" />
+          <g
+             id="g4410">
+            <g
+               style="opacity:0.75"
+               clip-path="url(#clipPath4406-2)"
+               id="g4412">
+              <g
+                 transform="translate(226.5947,1057.5327)"
+                 id="g4414">
+                <path
+                   d="m 0,0 -165.071,18.018 c 0,0 -33.538,-23.621 -38.469,-46.414 L 0,0 z"
+                   style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                   id="path4416" />
+              </g>
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4418">
+          <g
+             id="g4420" />
+          <g
+             id="g4426">
+            <g
+               style="opacity:0.75"
+               clip-path="url(#clipPath4422-1)"
+               id="g4428">
+              <g
+                 transform="translate(429.3799,871.9478)"
+                 id="g4430">
+                <path
+                   d="M 0,0 -149.953,51.734 -57.947,-65.618 0,0 z"
+                   style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                   id="path4432" />
+              </g>
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4434">
+          <g
+             id="g4436" />
+          <g
+             id="g4442">
+            <g
+               style="opacity:0.46000701"
+               clip-path="url(#clipPath4438-6)"
+               id="g4444">
+              <g
+                 transform="translate(154.6733,835.5776)"
+                 id="g4446">
+                <path
+                   d="M 0,0 -26.543,-80.113 -21.61,-105 0,0 z"
+                   style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                   id="path4448" />
+              </g>
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4450">
+          <g
+             id="g4452" />
+          <g
+             id="g4458">
+            <g
+               style="opacity:0.35000604"
+               clip-path="url(#clipPath4454-7)"
+               id="g4460">
+              <g
+                 transform="translate(291.6035,781.584)"
+                 id="g4462">
+                <path
+                   d="m 0,0 -78.443,-80.179 15.509,3.761 L 0,0 z"
+                   style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                   id="path4464" />
+              </g>
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4466">
+          <g
+             id="g4468" />
+          <g
+             id="g4474">
+            <g
+               style="opacity:0.80000299"
+               clip-path="url(#clipPath4470-1)"
+               id="g4476">
+              <g
+                 transform="translate(381.2881,753.5664)"
+                 id="g4478">
+                <path
+                   d="m 0,0 c -1.525,2.578 -207.802,-84.28 -207.802,-84.28 l 26.511,27.74 23.207,113.596 -0.078,-0.08 0.037,0.169 -80.609,-83.331 -7.91,-37.553 c 0,0 -44.889,219.273 -47.879,219.071 -2.991,-0.198 9.936,-197.083 9.936,-197.083 0,0 25.212,-90.83 25.55,-91.532 l -0.369,-0.691 c 0.212,-0.046 0.422,-0.063 0.621,-0.04 0.085,-0.129 0.174,-0.262 0.292,-0.38 l 0.313,0.59 c 0.764,0.117 89.956,30.637 89.956,30.637 0,0 169.748,100.59 168.224,103.167"
+                   style="fill:#b5def6;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                   id="path4480" />
+              </g>
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4482"
+           transform="translate(229.5801,1038.4639)">
+          <path
+             d="m 0,0 c -15.76,2.611 -29.876,-3.352 -31.525,-13.315 -1.579,-9.531 8.837,-19.254 23.542,-22.365 0.186,-4.086 4.978,-8.018 11.452,-9.089 7.061,-1.171 13.382,1.499 14.122,5.961 0.292,1.756 -0.351,3.517 -1.632,5.091 5.22,2.438 8.813,6.238 9.59,10.954 C 27.204,-12.798 15.759,-2.607 0,0"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4484" />
+        </g>
+        <g
+           id="g4486"
+           transform="translate(27.9131,986.1035)">
+          <path
+             d="M 0,0 C 0,0 23.08,-21.809 47.215,-42.748 71.354,-63.688 0.941,-9.844 -1.476,-5.723"
+             style="fill:#0988c9;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4488" />
+        </g>
+        <g
+           id="g4490">
+          <g
+             id="g4492" />
+          <g
+             id="g4498">
+            <g
+               style="opacity:0.80000299"
+               clip-path="url(#clipPath4494-2)"
+               id="g4500">
+              <g
+                 transform="translate(130.8423,615.7412)"
+                 id="g4502">
+                <path
+                   d="M 0,0 22.81,34.131 5.783,14.161 30.108,73.732 -3.891,12.177 -6.559,60.954 -10.331,0.518 0,0 z"
+                   style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                   id="path4504" />
+              </g>
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4506"
+           transform="translate(61.9531,1085.1133)">
+          <path
+             d="m 0,0 c -2.251,0 -4.271,-0.623 -6.005,-1.85 -22.572,-16.048 -36.33,-32.553 -40.909,-49.067 -4.07,-14.68 0.351,-25.281 1.804,-28.764 0.026,-0.061 0.05,-0.12 0.073,-0.175 2.202,-9.575 24.165,-102.033 46.464,-192.829 13.567,-55.244 24.702,-99.483 33.095,-131.49 4.975,-18.971 9.02,-33.763 12.025,-43.967 5.33,-18.099 6.95,-21.399 11.555,-23.541 1.398,-0.651 2.938,-0.983 4.568,-0.983 3.918,0 11.21,0 186.363,71.06 74.253,30.124 172.188,70.533 174.606,71.929 2.159,1.246 6.883,5.252 14.048,11.911 10.459,8.116 16.735,21.924 18.16,39.979 1.049,13.296 -0.79,24.881 -1.542,27.377 -0.633,2.101 -0.633,2.101 -16.93,23.947 -8.101,10.859 -19.368,25.908 -33.487,44.727 -24.034,32.035 -48.336,64.333 -48.579,64.655 l -1.328,1.765 -1.949,1.035 -178.171,94.697 -1.665,0.884 -1.873,0.214 C 143.229,-15.399 7.686,0 0,0 m 0,-9.937 c 7.511,0 169.198,-18.422 169.198,-18.422 l 178.171,-94.696 c 0,0 97.048,-128.979 97.422,-130.22 0.809,-2.685 6.766,-41.631 -13.521,-56.89 0,0 -10.27,-9.563 -12.598,-10.906 C 416.37,-322.4 77.31,-462.729 62.67,-462.729 c -0.169,0 -0.296,0.018 -0.378,0.056 -7.14,3.32 -96.845,381.106 -97.768,385.584 -0.586,2.842 -18.042,29.266 35.212,67.129 0.022,0.016 0.111,0.023 0.264,0.023"
+             style="fill:#0988c9;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4508" />
+        </g>
+        <g
+           id="g4510">
+          <g
+             id="g4512" />
+          <g
+             id="g4518">
+            <g
+               style="opacity:0.75"
+               clip-path="url(#clipPath4514-9)"
+               id="g4520">
+              <g
+                 transform="translate(415.5801,953.8745)"
+                 id="g4522">
+                <path
+                   d="m 0,0 90.854,-121.284 c 0,0 8.269,-36.543 -8.607,-53.531 L 0,0 z"
+                   style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                   id="path4524" />
+              </g>
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4526"
+           transform="translate(484.085,764.0322)">
+          <path
+             d="M 0,0 C 0,0 -43.743,4.662 -66.581,10.92 -89.424,17.177 -46.382,1.606 -2.888,-2.973"
+             style="fill:#0988c9;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4528" />
+        </g>
+        <g
+           id="g4530"
+           transform="translate(120.2432,628.8184)">
+          <path
+             d="m 0,0 c 2.207,3.001 -0.022,-7.418 7.543,-5.571 7.564,1.847 -4.215,-5.152 -4.714,-5.109 -0.497,0.044 -5.802,3.959 -5.821,4.462 C -3.01,-5.714 -2.208,-3 0,0"
+             style="fill:#0e89cb;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4532" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/images/singleuser/requirements.txt
+++ b/images/singleuser/requirements.txt
@@ -36,3 +36,6 @@ mycli
 
 # Interface with other languages
 rpy2
+
+# RStudio
+jupyter-rsession-proxy

--- a/images/singleuser/rsession.conf
+++ b/images/singleuser/rsession.conf
@@ -1,0 +1,2 @@
+# Use binary packages!
+r-cran-repos=https://packagemanager.rstudio.com/all/__linux__/focal/latest


### PR DESCRIPTION
Looks like OpenRefine is used in wikidata a bit
https://www.wikidata.org/wiki/Wikidata:Tools/OpenRefine,
so should be useful here

You can test this with:

`$ docker build -t paws images/singleuser`
`$ docker run -p 8888:8888 paws jupyter notebook --ip=0.0.0.0`

This should start a notebook server, and print a URL with a token
you can use to connect to the docker container & test the image.
Since this uses port forwarding, it'll most likely only work if you
are running docker locally (and not via docker-machine)

You can open RStudio by going to 'New -> OpenRefine'

Depends on #64, which depends on #62 