### PR TITLE
Add nbgitpuller to PAWS

### DIFF
--- a/images/singleuser/Dockerfile
+++ b/images/singleuser/Dockerfile
@@ -116,6 +116,7 @@ RUN pip install --no-cache-dir \
     jupyterhub==1.1.0 \
     notebook==6.3.* \
     jupyterlab==3.* \
+    nbgitpuller==0.9.0 \
     bash_kernel
 
 # Install the bash kernel


### PR DESCRIPTION
Over the last few years,
[nbgitpuller](https://jupyterhub.github.io/nbgitpuller/)
has become a very common way to distribute examples / learning materials
to participants in a workshop. This lets them start from a working base
but modify it as they want.

Once installed, you can create a specific link with
https://jupyterhub.github.io/nbgitpuller/link.html that points to
paws and to the git repo you want to 'pull'. If you use this link:
https://hub.paws.wmcloud.org/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fyuvipanda%2Frequirements&urlpath=tree%2Frequirements%2F&branch=master

it will pull in https://github.com/yuvipanda/requirements locally
and let you edit it. If someone changes the git repo, you can click it
again to pull in new changes.