### PR TITLE
remove openrefine pending security issue resolution

### DIFF
--- a/images/singleuser/Dockerfile
+++ b/images/singleuser/Dockerfile
@@ -89,11 +89,11 @@ RUN curl --silent --location --fail ${RSTUDIO_URL} > /tmp/rstudio.deb && \
     dpkg -i /tmp/rstudio.deb && \
     rm /tmp/rstudio.deb
 
-# Setup OpenRefine
-ENV OPENREFINE_DIR /srv/openrefine
-RUN mkdir -p ${OPENREFINE_DIR} && cd ${OPENREFINE_DIR} && \
-    curl -L https://github.com/OpenRefine/OpenRefine/releases/download/3.4.1/openrefine-linux-3.4.1.tar.gz | tar xzf - --strip=1
-COPY proxies/openrefine-logo.svg ${OPENREFINE_DIR}}/openrefine-logo.svg
+# Setup OpenRefine -- Not yet. See T283839
+#ENV OPENREFINE_DIR /srv/openrefine
+#RUN mkdir -p ${OPENREFINE_DIR} && cd ${OPENREFINE_DIR} && \
+#    curl -L https://github.com/OpenRefine/OpenRefine/releases/download/3.4.1/openrefine-linux-3.4.1.tar.gz | tar xzf - --strip=1
+#COPY proxies/openrefine-logo.svg ${OPENREFINE_DIR}}/openrefine-logo.svg
 
 # Machine-learning type stuff
 RUN apt-get install --yes \


### PR DESCRIPTION
Openrefine creates a workspace.json with cleartext secrets in
it that seems to just do whatever the umask says. Since PAWS is public
by default, that means the information is on the web.

This is actually already applied everywhere because the software also
changes the file back if you try to chmod it, meaning that it being
present is enough to keep opening your file to the internet.

Bug: T283839