### PR TITLE
restore openrefine now that it is more private

### DIFF
--- a/images/singleuser/Dockerfile
+++ b/images/singleuser/Dockerfile
@@ -89,11 +89,11 @@ RUN curl --silent --location --fail ${RSTUDIO_URL} > /tmp/rstudio.deb && \
     dpkg -i /tmp/rstudio.deb && \
     rm /tmp/rstudio.deb
 
-# Setup OpenRefine -- Not yet. See T283839
-#ENV OPENREFINE_DIR /srv/openrefine
-#RUN mkdir -p ${OPENREFINE_DIR} && cd ${OPENREFINE_DIR} && \
-#    curl -L https://github.com/OpenRefine/OpenRefine/releases/download/3.4.1/openrefine-linux-3.4.1.tar.gz | tar xzf - --strip=1
-#COPY proxies/openrefine-logo.svg ${OPENREFINE_DIR}}/openrefine-logo.svg
+# Setup OpenRefine
+ENV OPENREFINE_DIR /srv/openrefine
+RUN mkdir -p ${OPENREFINE_DIR} && cd ${OPENREFINE_DIR} && \
+    curl -L https://github.com/OpenRefine/OpenRefine/releases/download/3.4.1/openrefine-linux-3.4.1.tar.gz | tar xzf - --strip=1
+COPY proxies/openrefine-logo.svg ${OPENREFINE_DIR}}/openrefine-logo.svg
 
 # Machine-learning type stuff
 RUN apt-get install --yes \

--- a/images/singleuser/Dockerfile
+++ b/images/singleuser/Dockerfile
@@ -93,7 +93,7 @@ RUN curl --silent --location --fail ${RSTUDIO_URL} > /tmp/rstudio.deb && \
 ENV OPENREFINE_DIR /srv/openrefine
 RUN mkdir -p ${OPENREFINE_DIR} && cd ${OPENREFINE_DIR} && \
     curl -L https://github.com/OpenRefine/OpenRefine/releases/download/3.4.1/openrefine-linux-3.4.1.tar.gz | tar xzf - --strip=1
-COPY proxies/openrefine-logo.svg ${OPENREFINE_DIR}}/openrefine-logo.svg
+COPY proxies/openrefine-logo.svg ${OPENREFINE_DIR}/openrefine-logo.svg
 
 # Machine-learning type stuff
 RUN apt-get install --yes \


### PR DESCRIPTION
This as of now, all files from openrefine will be private, which isn't
great, but that's better than making them all public, perhaps.

Let's try turning it back on, perhaps.

Bug: T283839