### PR TITLE
install-mediawiki: use REL1_36

### DIFF
--- a/images/jobber/install-oauth.sh
+++ b/images/jobber/install-oauth.sh
@@ -1,6 +1,6 @@
 #!/bin/ash
 
-extension_url=$(curl 'https://www.mediawiki.org/w/api.php?action=query&list=extdistbranches&edbexts=OAuth&formatversion=2&format=json' | jq -r .query.extdistbranches.extensions.OAuth.REL1_34)
+extension_url=$(curl 'https://www.mediawiki.org/w/api.php?action=query&list=extdistbranches&edbexts=OAuth&formatversion=2&format=json' | jq -r .query.extdistbranches.extensions.OAuth.REL1_36)
 /usr/bin/curl -o OAuth.tar.gz "$extension_url"
 
 # Wait until the mediawiki pod creates the extensions dir in the PVC


### PR DESCRIPTION
MW 1.34 is no longer supported. Bump to 1.36, the latest stable version, instead.﻿
