### PR TITLE
Install a specific version of Pywikibot

### DIFF
--- a/images/singleuser/Dockerfile
+++ b/images/singleuser/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04
 
+ENV PYWIKIBOT_VERSION=6.6.1
 ENV EDITOR=/bin/nano
 ENV PYWIKIBOT_DIR=/srv/paws
 ENV DEBIAN_FRONTEND=noninteractive
@@ -183,7 +184,7 @@ RUN pip --no-cache-dir install -U pip 'setuptools<58' wheel
 RUN pip --no-cache-dir install -r /tmp/requirements.txt
 
 # Install pywikibot
-RUN git clone --branch stable --recursive https://gerrit.wikimedia.org/r/pywikibot/core.git /srv/paws/pwb
+RUN git clone --branch $PYWIKIBOT_VERSION --recursive https://gerrit.wikimedia.org/r/pywikibot/core.git /srv/paws/pwb
 COPY --chown=tools.paws:tools.paws user-config.py /srv/paws/
 COPY --chown=tools.paws:tools.paws user-fixes.py /srv/paws/
 


### PR DESCRIPTION
Installing the "stable" branch has the benefit of using the latest
release whenever the image is rebuilt. However, that means to get the
latest Pywikibot version, someone will need to do a no-change rebuild of
the image, bypassing Git and the standard CI/CD processes.

Specifying an explicit version means this will just work with docker
caching and cause a commit to go through CI/CD like all other changes.
It does mean that a new commit needs to be made for each new version.
LibUp will file a task in the #PAWS Phabricator project[1] every time a
new Pywikibot version is released so it doesn't get forgotten about.

I put the PYWIKIBOT_VERSION env at the top for easier readability, which
means bumping Pywikibot will invalidate the whole build cache. I'm not
sure if that's a good thing.

[1] https://gerrit.wikimedia.org/r/723018