### PR TITLE
Upgrade pip/setuptools/wheel right after venv creation

### DIFF
--- a/images/singleuser/Dockerfile
+++ b/images/singleuser/Dockerfile
@@ -145,6 +145,10 @@ ENV PATH=/srv/paws/pwb:/srv/paws/bin:/srv/paws:$PATH
 
 USER ${NB_USER}
 RUN python3 -m venv /srv/paws
+# Use setuptools<58 until all dependencies no longer have use_2to3
+# https://setuptools.pypa.io/en/latest/history.html#v58-0-0
+# https://github.com/vpelletier/pprofile/issues/41
+RUN pip --no-cache-dir install -U pip 'setuptools<58' wheel
 
 # Install base notebook packages
 RUN pip install --no-cache-dir \
@@ -176,10 +180,6 @@ RUN r -e "install.packages('IRkernel', version='1.1.1')" && \
 # Install mass amount of python libraries!
 COPY --chown=tools.paws:tools.paws requirements.txt /tmp/requirements.txt
 
-# Use setuptools<58 until all dependencies no longer have use_2to3
-# https://setuptools.pypa.io/en/latest/history.html#v58-0-0
-# https://github.com/vpelletier/pprofile/issues/41
-RUN pip --no-cache-dir install -U pip 'setuptools<58' wheel
 RUN pip --no-cache-dir install -r /tmp/requirements.txt
 
 # Install pywikibot


### PR DESCRIPTION
In c77ca1f4a923c30 I missed that the base notebook packages were being
installed even earlier. The upgrade of pip/setuptools/wheel now happens
immediately after venv creation, so it'll be there for all dependencies
as originally intended.