### PR TITLE
renderer to include md and rst files

### DIFF
--- a/images/nbserve/nginx.py
+++ b/images/nbserve/nginx.py
@@ -98,7 +98,7 @@ http {
         }
 
         # Only after the User: redirect! Otherwise our backend can't find the file.
-        location ~ ^/\d+/.*\.ipynb$ {
+        location ~ ^/\d+/.*\.(rst|md|ipynb)$ {
             include /usr/local/openresty/nginx/conf/uwsgi_params;
             uwsgi_pass uwsgi://%s:8000;
         }

--- a/images/renderer/Dockerfile
+++ b/images/renderer/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install git+https://github.com/jupyter/nbconvert.git ipython werkzeug
+RUN pip3 install git+https://github.com/jupyter/nbconvert.git ipython werkzeug markdown docutils
 
 COPY renderer.py /srv/renderer.py
 COPY basic.tpl /srv/basic.tpl

--- a/images/renderer/renderer.py
+++ b/images/renderer/renderer.py
@@ -2,6 +2,8 @@ from werkzeug.wrappers import Request, Response
 from nbconvert.exporters import HTMLExporter
 
 import os
+import markdown
+import docutils.core
 
 BASE_PATH = os.environ["BASE_PATH"]
 URL_PREFIX = os.environ["URL_PREFIX"]
@@ -29,8 +31,30 @@ def render_ipynb(full_path, format):
     return Response(html, mimetype="text/html")
 
 
+def render_md(full_path, format):
+    """
+    Render a given markdown file
+    """
+    with open(full_path, encoding="utf-8") as file_handle:
+        text = file_handle.read()
+    html = markdown.markdown(text)
+    return Response(html, mimetype="text/html")
+
+
+def render_rst(full_path, format):
+    """
+    Render a given reStructuredText file
+    """
+    with open(full_path, encoding="utf-8") as file_handle:
+        text = file_handle.read()
+    html = docutils.core.publish_string(source=text, writer_name="html")
+    return Response(html, mimetype="text/html")
+
+
 # Map of extensions to functions to call for handling them
 handlers = {
+    "rst": render_rst,
+    "md": render_md,
     "ipynb": render_ipynb,
 }
 

--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -12,14 +12,14 @@ pawspublic:
   nbserve:
     image:
       name: quay.io/wikimedia-paws-prod/nbserve
-      tag: latest
+      tag: 21.10.01
       # pawspublic.nbserve.image.template safely defines image:tag name in yaml
       template: "{{ .Values.pawspublic.nbserve.image.name}}:{{.Values.pawspublic.nbserve.image.tag }}"
     replicas: 1
   renderer:
     image:
-      name: docker-registry.tools.wmflabs.org/toolforge-paws-public-renderer
-      tag: latest
+      name: quay.io/wikimedia-paws-prod/renderer
+      tag: 21.10.01
       # pawspublic.nbserve.image.template safely defines image:tag name in yaml
       template: "{{ .Values.pawspublic.renderer.image.name}}:{{.Values.pawspublic.renderer.image.tag }}"
     replicas: 1


### PR DESCRIPTION
(minikube1.23 is now merged, shouldn't need to do any merge tricks for this now) To test this update I updated my hosts file with:
`minikube ip` public.paws.wmcloud.org
`minikube ip` paws.wmcloud.org
`minikube ip` hub.paws.wmcloud.org
At which point notebooks would appear as described in "Alter the URL manually" :
https://wikitech.wikimedia.org/wiki/PAWS/Getting_started_with_PAWS#Share