### PR TITLE
Enable PRs from fork to build containers

### DIFF
--- a/.github/workflows/jobber.yaml
+++ b/.github/workflows/jobber.yaml
@@ -1,14 +1,14 @@
 name: build and push jobber
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - images/jobber/**
 
 jobs:
   build-and-push:
     name: build and push jobber
-    uses: toolforge/github-actions/.github/workflows/build-and-push.yaml@build-and-push-v1
+    uses: toolforge/github-actions/.github/workflows/build-and-push.yaml@build-and-push-v2
     with:
       imagename: jobber
     secrets:

--- a/.github/workflows/nbserve.yaml
+++ b/.github/workflows/nbserve.yaml
@@ -1,14 +1,14 @@
 name: build and push nbserve
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - images/nbserve/**
 
 jobs:
   build-and-push:
     name: build and push nbserve
-    uses: toolforge/github-actions/.github/workflows/build-and-push.yaml@build-and-push-v1
+    uses: toolforge/github-actions/.github/workflows/build-and-push.yaml@build-and-push-v2
     with:
       imagename: nbserve
     secrets:

--- a/.github/workflows/paws-hub.yaml
+++ b/.github/workflows/paws-hub.yaml
@@ -1,14 +1,14 @@
 name: build and push paws-hub
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - images/paws-hub/**
 
 jobs:
   build-and-push:
     name: build and push paws-hub
-    uses: toolforge/github-actions/.github/workflows/build-and-push.yaml@build-and-push-v1
+    uses: toolforge/github-actions/.github/workflows/build-and-push.yaml@build-and-push-v2
     with:
       imagename: paws-hub
     secrets:

--- a/.github/workflows/renderer.yaml
+++ b/.github/workflows/renderer.yaml
@@ -1,14 +1,14 @@
 name: build and push renderer
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - images/renderer/**
 
 jobs:
   build-and-push:
     name: build and push renderer
-    uses: toolforge/github-actions/.github/workflows/build-and-push.yaml@build-and-push-v1
+    uses: toolforge/github-actions/.github/workflows/build-and-push.yaml@build-and-push-v2
     with:
       imagename: renderer
     secrets:

--- a/.github/workflows/singleuser.yaml
+++ b/.github/workflows/singleuser.yaml
@@ -1,7 +1,7 @@
 name: build and push singleuser
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - images/singleuser/**
 
@@ -9,7 +9,7 @@ on:
 jobs:
   build-and-push:
     name: build and push singleuser
-    uses: toolforge/github-actions/.github/workflows/build-and-push.yaml@build-and-push-v1
+    uses: toolforge/github-actions/.github/workflows/build-and-push.yaml@build-and-push-v2
     with:
       imagename: singleuser
     secrets:

--- a/.github/workflows/update-container-tags.yaml
+++ b/.github/workflows/update-container-tags.yaml
@@ -1,7 +1,7 @@
 name: update container tags
 
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   update-container-tags:
@@ -10,10 +10,14 @@ jobs:
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: git fetch
         run: |
           git fetch
+      - name: git checkout
+        run: |
+          git checkout ${{ github.head_ref }}
 
 # Github actions doesn't have much in the way of loops. Using a matrix results
 # in multiple separate jobs being run, which will try to overwrite one another.


### PR DESCRIPTION
This change will enable a PR from a fork (rather than an internal branch) to run the workflows. In particular the PR will be able to build a container, and push it to quay (with the pr-<pr number>) tag. So long as the PR submitter enabled the "Allow edits and access to secrets by maintainers" this will also go and update their values.yaml with the docker tag that the pr built.

This does open the door to some injection possibilities:
https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
First the scope that we are talking about is two creds, one the robot account personal access token used by the commit, and the second a robot account token with write access to the five quay.io registries that the workflows manage.

According to the above the access token should be fine. As it doesn't compile or run the code that it pulls, just updates values and pushes it back out.

The quay.io robot does build the code that it is given. We could switch this to a "workflow_run" model, however I found that awkward, as the job could run, but wouldn't show up under the "Checks" section of a pr (it was visible in the overall "Actions" menu). This appears to be known:
https://github.community/t/workflow-run-runs-but-not-showing-in-the-pr-checks/183493
This makes it somewhat cumbersome to identify what stage the job is really in, and with the larger singleuser container result in the PR checks appearing done, but the container not being in quay.io yet, causing various confusion. As such I worked on it as a pull_request_target job instead. I don't believe there is a way to inject the token into the container and have it readable there. Though I could be wrong. If it were compromised we could end up with the quay.io containers being deleted, or replaced with some kind of junk.

At time of writing there is an additional protection, anyone without write access to the PAWS repo will need someone with write to run the workflow for them. So strange stuff shouldn't be able to run without someone looking at it.

https://github.com/toolforge/paws/pull/76 is something of a test for this. If we merge this PR, 76 should be able to run and build.

bug: T295754