### PR TITLE
Revert "Bump openrefine to 3.5.0"

### DIFF
--- a/images/singleuser/Dockerfile
+++ b/images/singleuser/Dockerfile
@@ -94,7 +94,7 @@ RUN curl --silent --location --fail ${RSTUDIO_URL} > /tmp/rstudio.deb && \
 # Setup OpenRefine
 ENV OPENREFINE_DIR /srv/openrefine
 RUN mkdir -p ${OPENREFINE_DIR} && cd ${OPENREFINE_DIR} && \
-    curl -L https://github.com/OpenRefine/OpenRefine/releases/download/3.5.0/openrefine-linux-3.5.0.tar.gz | tar xzf - --strip=1
+    curl -L https://github.com/OpenRefine/OpenRefine/releases/download/3.4.1/openrefine-linux-3.4.1.tar.gz | tar xzf - --strip=1
 COPY proxies/openrefine-logo.svg ${OPENREFINE_DIR}/openrefine-logo.svg
 
 # Machine-learning type stuff

--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -278,7 +278,7 @@ jupyterhub:
     fsGid: 52771
     image:
       name: quay.io/wikimedia-paws-prod/singleuser
-      tag: pr-110 # singleuser tag managed by github actions
+      tag: pr-114 # singleuser tag managed by github actions
       pullPolicy: Always
     memory:
       guarantee: 1G


### PR DESCRIPTION
This reverts commit 4b7e9798690916310b2e04bc207034f2e70b9cb7.

If I'm understanding correctly this is necessary to unblock changes to the singleuser container. And will go back in as part of
https://github.com/toolforge/paws/pull/111