### PR TITLE
images/singleuser: Add wmpaws to requirements

### DIFF
--- a/images/singleuser/requirements.txt
+++ b/images/singleuser/requirements.txt
@@ -37,6 +37,7 @@ beautifulsoup4
 # SQL!
 pymysql
 mycli
+wmpaws
 
 # Interface with other languages
 rpy2

--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -278,7 +278,7 @@ jupyterhub:
     fsGid: 52771
     image:
       name: quay.io/wikimedia-paws-prod/singleuser
-      tag: pr-121 # singleuser tag managed by github actions
+      tag: pr-122 # singleuser tag managed by github actions
       pullPolicy: Always
     memory:
       guarantee: 1G


### PR DESCRIPTION
wmpaws makes it simpler to run SQL queries against
replicas: compare `wmpaws.run_sql('...', 'cswiki')`
with a lot of boilerplate code in the currently recommmended way:
https://public.paws.wmcloud.org/User:JHernandez_(WMF)/Accessing%20Wikireplicas%20from%20PAWS.ipynb

Bug: T298189