### PR TITLE
older jupyter-rsession-proxy to get rstudio working

### DIFF
--- a/images/singleuser/requirements.txt
+++ b/images/singleuser/requirements.txt
@@ -43,7 +43,7 @@ wmpaws
 rpy2
 
 # RStudio
-jupyter-rsession-proxy
+jupyter-rsession-proxy==1.4
 
 # Web dev stuff
 flask

--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -278,7 +278,7 @@ jupyterhub:
     fsGid: 52771
     image:
       name: quay.io/wikimedia-paws-prod/singleuser
-      tag: pr-124 # singleuser tag managed by github actions
+      tag: pr-128 # singleuser tag managed by github actions
       pullPolicy: Always
     memory:
       guarantee: 1G


### PR DESCRIPTION
Gets rstudio working in minikube.

Opening https://phabricator.wikimedia.org/T302164 to track the upgrading of jupyter-rsession-proxy