### PR TITLE
pin jupyterlab version

### DIFF
--- a/images/singleuser/Dockerfile
+++ b/images/singleuser/Dockerfile
@@ -161,7 +161,7 @@ RUN pip --no-cache-dir install -U pip setuptools wheel
 # Install base notebook packages
 RUN pip install --no-cache-dir \
     jupyterhub==2.1.1 \
-    jupyterlab>=3.2.4 \
+    jupyterlab==3.3.4 \
     retrolab \
     jupyterlab-link-share>=0.2.4 \
     nbgitpuller==0.9.0 \

--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -282,7 +282,7 @@ jupyterhub:
     fsGid: 52771
     image:
       name: quay.io/wikimedia-paws-prod/singleuser
-      tag: pr-144 # singleuser tag managed by github actions
+      tag: pr-147 # singleuser tag managed by github actions
       pullPolicy: Always
     memory:
       guarantee: 1G


### PR DESCRIPTION
as current update to 3.4.0 fails to build on crypto
see:
https://phabricator.wikimedia.org/T307919
https://github.com/toolforge/paws/pull/145
for more information.