### PR TITLE
bump jupyterhub version

### DIFF
--- a/images/singleuser/Dockerfile
+++ b/images/singleuser/Dockerfile
@@ -160,7 +160,7 @@ RUN pip --no-cache-dir install -U pip setuptools wheel
 
 # Install base notebook packages
 RUN pip install --no-cache-dir \
-    jupyterhub==2.1.1 \
+    jupyterhub==2.3.0 \
     jupyterlab==3.3.4 \
     retrolab \
     jupyterlab-link-share>=0.2.4 \

--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -282,7 +282,7 @@ jupyterhub:
     fsGid: 52771
     image:
       name: quay.io/wikimedia-paws-prod/singleuser
-      tag: pr-145 # singleuser tag managed by github actions
+      tag: pr-149 # singleuser tag managed by github actions
       pullPolicy: Always
     memory:
       guarantee: 1G


### PR DESCRIPTION
In addition to getting this up to a newer jupyerhub version,
it also appears to fix an issue with jupyterlab-link-share,
where it was not sharing a token, thus was not working.

Bug: T308568