### PR TITLE
autoscaling for renderer deployment

### DIFF
--- a/paws/production.yaml
+++ b/paws/production.yaml
@@ -27,3 +27,5 @@ localdev:
 pawspublic:
   ingress:
     host: public.paws.wmcloud.org
+  renderer:
+    cpu: "500m"

--- a/paws/templates/public.yaml
+++ b/paws/templates/public.yaml
@@ -53,7 +53,6 @@ metadata:
     name: renderer
   name: renderer
 spec:
-  replicas: {{ .Values.pawspublic.renderer.replicas }}
   selector:
     matchLabels:
       name: renderer
@@ -82,11 +81,24 @@ spec:
           resources:
             requests:
               memory: "1000Mi"
-              cpu: "10m"
+              cpu: {{ .Values.pawspublic.renderer.cpu }}
       volumes:
         - hostPath:
             path: /data/project/paws/userhomes
           name: pawshomes
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: renderer
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: renderer
+  minReplicas: 1
+  maxReplicas: 6
+  targetCPUUtilizationPercentage: 200
 ---
 apiVersion: v1
 kind: Service

--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -16,7 +16,7 @@ pawspublic:
       tag: pr-168 # renderer tag managed by github actions
       # pawspublic.nbserve.image.template safely defines image:tag name in yaml
       template: "{{ .Values.pawspublic.renderer.image.name}}:{{.Values.pawspublic.renderer.image.tag }}"
-    replicas: 1
+    cpu: "10m" # give a token amount for local dev
   ingress:
     host: public.hub.paws.local
     legacyHost: paws-public.wmflabs.org


### PR DESCRIPTION
Sometimes the renderer gets pinned from requests.
Autoscaling should prevent it from getting overloaded.

Bug: T320776