### PR TITLE
startup script for minikube

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+k8s_version='v1.21.8'
+
+# check that we have dependencies
+for command in kubectl helm minikube ; do
+    if ! command -v ${command} > /dev/null ; then
+        echo "${command} was not found"
+        echo "please install ${command} before proceeding"
+        exit 1
+    fi
+done
+
+# Rather than mess with people's minikube setup let them know about it and ask them to fix it
+if ! kubectl get nodes | tail -1 | awk '{print $NF}' | grep "${k8s_version}" > /dev/null ; then
+    if minikube status > /dev/null ; then
+        echo "minikube is running but not on k8s version ${k8s_version}."
+    else
+        echo "minikube is not running."
+    fi
+    echo "Please create and start a cluster running ${k8s_version}. Perhaps by running:"
+    echo "minikube start --kubernetes-version=${k8s_version}"
+    echo "Then rerun this script."
+    exit 1
+fi
+
+# these steps are fast, just run them
+minikube addons enable ingress
+helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
+helm dep up paws/
+kubectl create namespace paws-dev --dry-run=client -o yaml | kubectl apply -f -
+kubectl config set-context --current --namespace=paws-dev
+
+if helm status -n paws-dev dev 2>&1 > /dev/null ; then
+    helm -n paws-dev upgrade dev paws/ --timeout=50m
+else
+    helm -n paws-dev install dev paws/ --timeout=50m
+fi


### PR DESCRIPTION
Bug: T322303

This is largely driven by https://wikitech.wikimedia.org/wiki/Wikimedia_Cloud_Services_team/EnhancementProposals/Decision_record_T303931_k8s_standard_deployment_code_pattern

In this case this is looking like a solution in want of a problem. I suspect that the above decision was made with tools that have a more specific build environment in mind. PAWS is setup to be run from someone's own system, which could be setup in any way that they deem fit. This large unknown makes it difficult to make much sense of what we should and should not do with a startup script. As I wouldn't want to erode user trust by building a script that, for example, would reconstruct their minikube env, potentially breaking all kinds of things for them. As such that was left out of this script. Beyond that it remains questionable to me how much we can really benefit from this that the current instructions in the README wouldn't solve.

The primary benefit appears to be that this could limit the number of copy and paste actions that would be taken. Beyond that it doesn't seem like something that you would really want to use. The script won't fix much for you, so if you aren't familiar with kubectl or helm and they give an error, you would still be stuck figuring out what the problem with those services would be. Doing the additional work to get this script to be more useful in that front seems like a silly task considering how much work it would be, to, at best, save copying and pasting a few commands out of the README.