### PR TITLE
lower single user cpu request

### DIFF
--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -288,7 +288,7 @@ jupyterhub:
       guarantee: 1G
       limit: 3G
     cpu:
-      guarantee: .5
+      guarantee: .15
       limit: 1
     storage:
       type: none


### PR DESCRIPTION
Currently single user cpu request is about 50x the average request Lowering to better resemble typical usage. Limit remains the same As such heavy users should not be imnpacted.

Bug: T327204