### PR TITLE
nbserve: Serve a deny-all robots.txt file

### DIFF
--- a/images/nbserve/Dockerfile
+++ b/images/nbserve/Dockerfile
@@ -82,6 +82,8 @@ RUN apt-get clean \
 
 EXPOSE 8000
 
+ADD robots.txt /var/www/robots.txt
+
 CMD ["/usr/local/openresty/bin/openresty", "-c", "/mnt/nginx.conf"]
 
 # Use SIGQUIT instead of default SIGTERM to cleanly drain requests

--- a/images/nbserve/robots.txt
+++ b/images/nbserve/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/paws/templates/nbserve/nginx.yaml
+++ b/paws/templates/nbserve/nginx.yaml
@@ -95,6 +95,10 @@ data:
                 deny all;
             }
 
+            location = /robots.txt {
+                alias /var/www/robots.txt;
+            }
+
             # No port numbes in redirects
             port_in_redirect off;
 

--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -6,7 +6,7 @@ pawspublic:
   nbserve:
     image:
       name: quay.io/wikimedia-paws-prod/nbserve
-      tag: pr-227 # nbserve tag managed by github actions
+      tag: pr-277 # nbserve tag managed by github actions
       # pawspublic.nbserve.image.template safely defines image:tag name in yaml
       template: "{{ .Values.pawspublic.nbserve.image.name}}:{{.Values.pawspublic.nbserve.image.tag }}"
     replicas: 1


### PR DESCRIPTION
To replace the robots.txt file someone added to the NFS root (which then
broke maintain-dbusers).

Untested, unfortunately.
