### PR TITLE
Remove jupyter-dash

### DIFF
--- a/images/singleuser/requirements.txt
+++ b/images/singleuser/requirements.txt
@@ -22,7 +22,6 @@ bqplot
 plotly
 holoviews[recommended]
 streamlit
-jupyter-dash
 
 # scientific stuff
 pandas

--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -280,7 +280,7 @@ jupyterhub:
     fsGid: 52771
     image:
       name: quay.io/wikimedia-paws-prod/singleuser
-      tag: pr-381 # singleuser tag managed by github actions
+      tag: pr-382 # singleuser tag managed by github actions
       pullPolicy: Always
     memory:
       guarantee: 0.70G


### PR DESCRIPTION
No longer needed according to https://github.com/plotly/jupyter-dash

Bug: T358621