### PR TITLE
Upgrade labpawspublic

### DIFF
--- a/images/singleuser/install-extensions
+++ b/images/singleuser/install-extensions
@@ -10,7 +10,7 @@ pip install --no-cache-dir \
     RISE \
     py-heat-magic \
     jupyter-resource-usage \
-    git+https://github.com/toolforge/labpawspublic@08b8b4f89143055df024ebbbfb159b07f0f2a5b0 \
+    git+https://github.com/toolforge/labpawspublic@10ba684789ff5b6e0e2e2122ce68be101266acb8 \
 #    git+https://github.com/toolforge/paws-favicon@v1.0 \
 
 # Rebuild JupyterLab for plotly-dash extension

--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -280,7 +280,7 @@ jupyterhub:
     fsGid: 52771
     image:
       name: quay.io/wikimedia-paws-prod/singleuser
-      tag: pr-437 # singleuser tag managed by github actions
+      tag: pr-439 # singleuser tag managed by github actions
       pullPolicy: Always
     memory:
       guarantee: 0.70G


### PR DESCRIPTION
Bug: [T358604](https://phabricator.wikimedia.org/T358604)

Live installing the new labpawspublic version in a running server yields the expected links and menu items.
![telegram-cloud-document-1-4929588158963647895](https://github.com/toolforge/paws/assets/188585/e430171a-70e4-4818-950e-640c3e6e7f1b)
<img width="416" alt="image" src="https://github.com/toolforge/paws/assets/188585/361039ca-112a-4bdf-b71a-07fb278dfe73">
