### PR TITLE
Block non-HTTP connections to external IPs

### DIFF
--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -299,7 +299,20 @@ jupyterhub:
       REFINE_DOMAIN: "*"  # Check jupyterhub.ingress.hosts
     networkPolicy:
       egressAllowRules:
-        privateIPs: true  # needed for access to replicas
+        privateIPs: true  # Allow all connections to private IPs, needed for access to replicas
+        nonPrivateIPs: false # Block all connections to non-private IPs, except the ones allowed below
+      egress:
+        # Allow connections to non-private IPs only for TCP ports 80 and 443
+        # and for UDP ports 53 (DNS) and 123 (NTP)
+        - ports:
+            - protocol: TCP
+              port: 80
+            - protocol: TCP
+              port: 443
+            - protocol: UDP
+              port: 53
+            - protocol: UDP
+              port: 123
 # mysql configures the wiki replica backend variables
 mysql:
   domain: "svc.cluster.local"


### PR DESCRIPTION
I'm not sure what kind of network connections PAWS users need from their
notebooks, but I assume most will be HTTP/S connections to external
websites or APIs, or Git repositories served over HTTP/S.

Connections to UDP ports 53 (DNS) and 123 (NTP) are also legitimate.

Blocking other types of ports and protocols should prevent several forms
of malicious traffic that could originate from PAWS.

Bug: [T381373](https://phabricator.wikimedia.org/T381373)