### PR TITLE
Remove redundant config for proxy component

### DIFF
--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -53,12 +53,6 @@ jupyterhub:
       containerSecurityContext:
         runAsUser: 52771
         runAsGroup: 52771
-    # jupyterhub.proxy.secretToken is a valid dummy value for development
-    secretToken: "23f542cc4b1af000e68088f1acc7ca8275a67cf496bae15ead6a79b8c6702597"
-    service:
-      nodePorts:
-        http: 32611
-      type: NodePort
   cull:
     timeout: 86400
   hub:


### PR DESCRIPTION
* I don't think we need NodePort as the service is exposed through an ingress
* According to the docs [0] proxy.secretToken is now generated automatically

[0] https://z2jh.jupyter.org/en/stable/resources/reference.html#proxy-secrettoken