### PR TITLE
Use ClusterIP for proxy service

### DIFF
--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -53,6 +53,8 @@ jupyterhub:
       containerSecurityContext:
         runAsUser: 52771
         runAsGroup: 52771
+    service:
+      type: ClusterIP
   cull:
     timeout: 86400
   hub:


### PR DESCRIPTION
The default is LoadBalancer, which creates an Octavia load balancer to expose the proxy. But we already expose the proxy via an Ingress, so we can set the proxy service to "type: ClusterIP".