### PR TITLE
logo: move to a path that's not hidden by a volume

### DIFF
--- a/images/paws-hub/Dockerfile
+++ b/images/paws-hub/Dockerfile
@@ -10,7 +10,7 @@ RUN adduser --disabled-password \
     --force-badname \
     ${NB_USER}
 
-COPY PAWS.svg /srv/jupyterhub
+COPY PAWS.svg /usr/local/share/jupyterhub/static/PAWS.svg
 COPY paws-favicon.ico /usr/local/share/jupyterhub/static/favicon.ico
 
 RUN chown -R ${NB_USER}:${NB_USER} /srv/jupyterhub

--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -232,7 +232,7 @@ jupyterhub:
           c.OAuthenticator.allow_all = True
           c.JupyterHub.authenticator_class = Auth
           c.JupyterHub.authenticate_prometheus = False
-          c.JupyterHub.logo_file = '/srv/jupyterhub/PAWS.svg'
+          c.JupyterHub.logo_file = '/usr/local/share/jupyterhub/static/PAWS.svg'
           c.JupyterHub.template_vars = {
               'announcement': ('<span class="alert-success">'
                               'Welcome to PAWS. '


### PR DESCRIPTION
Currently /srv/jupyterhub is the path we use to mount the pvc that has the sqlite database, so it hides the logo image and then hub can't serve it. This moves it to some other place where we don't mount a volume so it can be served without issues.