### PR TITLE
Mount dumps only in singleuser containers

### DIFF
--- a/paws/codfw.yaml
+++ b/paws/codfw.yaml
@@ -11,19 +11,7 @@ jupyterhub:
         nfs:
           server: pawsdev-nfs.pawsdev.codfw1dev.wikimedia.cloud
           path: /srv/paws/project
-      - name: dumps
-        nfs:
-          server: pawsdev-nfs.pawsdev.codfw1dev.wikimedia.cloud
-          path: /
-      # Without this, dumps becomes inaccessible and can hang the host
-      - name: dumps-src1
-        nfs:
-          server: pawsdev-nfs.pawsdev.codfw1dev.wikimedia.cloud
-          path: /
-      - name: dumps-src2
-        nfs:
-          server: pawsdev-nfs.pawsdev.codfw1dev.wikimedia.cloud
-          path: /
+
     extraConfig:
       00-myConfig: |
           localdev = False

--- a/paws/production.yaml
+++ b/paws/production.yaml
@@ -11,19 +11,7 @@ jupyterhub:
         nfs:
           server: paws-nfs.svc.paws.eqiad1.wikimedia.cloud
           path: /srv/paws/project
-      - name: dumps
-        nfs:
-          server: clouddumps1002.wikimedia.org
-          path: /
-      # Without this, dumps becomes inaccessible and can hang the host
-      - name: dumps-src1
-        nfs:
-          server: clouddumps1001.wikimedia.org
-          path: /
-      - name: dumps-src2
-        nfs:
-          server: clouddumps1002.wikimedia.org
-          path: /
+
     extraConfig:
       00-myConfig: |
           localdev = False

--- a/paws/templates/localdev.yaml
+++ b/paws/templates/localdev.yaml
@@ -13,42 +13,6 @@ spec:
   hostPath:
     path: /srv/paws/project/paws/userhomes
 ---
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: dumps1
-spec:
-  accessModes:
-    - ReadOnlyMany
-  capacity:
-    storage: 1Gi
-  hostPath:
-    path: /mnt/nfs/dumps-clouddumps1001.wikimedia.org
----
-kind: PersistentVolume
-apiVersion: v1
-metadata:
-  name: dumps2
-spec:
-  accessModes:
-    - ReadOnlyMany
-  capacity:
-    storage: 1Gi
-  hostPath:
-    path: /mnt/nfs/dumps-clouddumps1002.wikimedia.org
----
-kind: PersistentVolume
-apiVersion: v1
-metadata:
-  name: dumps
-spec:
-  accessModes:
-    - ReadOnlyMany
-  capacity:
-    storage: 1Gi
-  hostPath:
-    path: /mnt/public/dumps
----
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -75,30 +75,9 @@ jupyterhub:
       - name: homes
         hostPath:
           path: /srv/paws/project
-      - name: dumps
-        hostPath:
-          path: /mnt/public/dumps
-      # Without this, dumps becomes inaccessible and can hang the host
-      - name: dumps-src1
-        hostPath:
-          path: /mnt/nfs/dumps-clouddumps1001.wikimedia.org
-          type: DirectoryOrCreate
-      - name: dumps-src2
-        hostPath:
-          path: /mnt/nfs/dumps-clouddumps1002.wikimedia.org
-          type: DirectoryOrCreate
     extraVolumeMounts:
       - name: homes
         mountPath: /data/project
-      - name: dumps
-        mountPath: /public/dumps
-        readOnly: true
-      - name: dumps-src1
-        mountPath: /mnt/nfs/dumps-clouddumps1001.wikimedia.org
-        readOnly: true
-      - name: dumps-src2
-        mountPath: /mnt/nfs/dumps-clouddumps1002.wikimedia.org
-        readOnly: true
     extraConfig:
       fixLabels: |
           def fix_labels(spawner, pod):


### PR DESCRIPTION
The only pod/container needing dumps-nfs mounts is `singleuser`, thus avoid mounting nfs anywhere else.