### PR TITLE
Enable maintain-dumps-nfs

### DIFF
--- a/images/maintain-dumps-nfs/Dockerfile
+++ b/images/maintain-dumps-nfs/Dockerfile
@@ -2,4 +2,5 @@ FROM alpine:3.20.0
 
 RUN apk add --no-cache python3 nfs-utils util-linux
 
+# always!
 ENV PYTHONUNBUFFERED=1

--- a/paws/codfw.yaml
+++ b/paws/codfw.yaml
@@ -16,8 +16,6 @@ jupyterhub:
       00-myConfig: |
           localdev = False
           nfs_home = 'pawsdev-nfs.pawsdev.codfw1dev.wikimedia.cloud'
-          dumps_src1 = 'pawsdev-nfs.pawsdev.codfw1dev.wikimedia.cloud'
-          dumps_src2 = 'pawsdev-nfs.pawsdev.codfw1dev.wikimedia.cloud'
   ingress:
     enabled: true
     hosts:
@@ -28,7 +26,7 @@ jupyterhub:
 minesweeper:
   enabled: true
 maintainDumpsNfs:
-  enabled: false
+  enabled: true
   server: pawsdev-nfs.pawsdev.codfw1dev.wikimedia.cloud
   affinity:
     nodeAffinity:

--- a/paws/production.yaml
+++ b/paws/production.yaml
@@ -16,8 +16,6 @@ jupyterhub:
       00-myConfig: |
           localdev = False
           nfs_home = 'paws-nfs.svc.paws.eqiad1.wikimedia.cloud'
-          dumps_src1 = 'clouddumps1001.wikimedia.org'
-          dumps_src2 = 'clouddumps1002.wikimedia.org'
   ingress:
     enabled: true
     hosts:
@@ -28,7 +26,7 @@ jupyterhub:
 minesweeper:
   enabled: true
 maintainDumpsNfs:
-  enabled: false
+  enabled: true
   server: dumps-nfs.wikimedia.org
   affinity:
     nodeAffinity:

--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -139,44 +139,38 @@ jupyterhub:
                   homenfs = '/srv/paws/project/paws/userhomes/{}'.format(identity['sub'])
                   # Create the homedir so docker doesn't do it as root
                   os.makedirs(homedir, mode=0o755, exist_ok=True)
+
+                  # Common spawner volumes from the host. Contents are managed
+                  # by maintain-dumps-nfs:
+                  # * mnt-nfs holds the nfs mount to dumps-nfs.w.o and gets
+                  # re-mounted as needed, hence the mountPropagation option.
+                  # * public-dumps is the public interface and holds a symlink to /mnt/nfs
+
+                  spawner.volumes = [
+                          {
+                              'name': 'public-dumps',
+                              'hostPath': { 'path': '/public/dumps' }
+                          },
+                          {
+                              'name': 'mnt-nfs',
+                              'hostPath': { 'path': '/mnt/nfs' }
+                          },
+                  ]
+
                   if localdev == True:
-                      spawner.volumes = [
+                      spawner.volumes.extend([
                           {
                               'name': 'home',
                               'hostPath': { 'path': homenfs }
                           },
-                          {
-                              'name': 'dumps',
-                              'hostPath': { 'path': '/public/dumps' }
-                          },
-                          {
-                              'name': 'dumps-src1',
-                              'hostPath': { 'path': '/mnt/nfs/dumps-clouddumps1001.wikimedia.org' }
-                          },
-                          {
-                              'name': 'dumps-src2',
-                              'hostPath': { 'path': '/mnt/nfs/dumps-clouddumps1002.wikimedia.org' }
-                          }
-                      ]
+                      ])
                   else:
-                      spawner.volumes = [
+                      spawner.volumes.extend([
                           {
                               'name': 'home',
                               'nfs': { 'server': nfs_home, 'path': homenfs }
                           },
-                          {
-                              'name': 'dumps',
-                              'nfs': { 'server': dumps_src1, 'path': '/' }
-                          },
-                          {
-                              'name': 'dumps-src1',
-                              'nfs': { 'server': dumps_src1, 'path': '/' }
-                          },
-                          {
-                              'name': 'dumps-src2',
-                              'nfs': { 'server': dumps_src2, 'path': '/' }
-                          }
-                      ]
+                      ])
 
                   spawner.volume_mounts = [
                       {
@@ -184,18 +178,14 @@ jupyterhub:
                           'mountPath': '/home/paws'
                       },
                       {
-                          'name': 'dumps',
-                          'mountPath': '/public/dumps/public',
+                          'name': 'public-dumps',
+                          'mountPath': '/public/dumps',
                           'readOnly': True
                       },
                       {
-                          'name': 'dumps-src1',
-                          'mountPath': '/mnt/nfs/dumps-clouddumps1001.wikimedia.org',
-                          'readOnly': True
-                      },
-                      {
-                          'name': 'dumps-src2',
-                          'mountPath': '/mnt/nfs/dumps-clouddumps1002.wikimedia.org',
+                          'name': 'mnt-nfs',
+                          'mountPath': '/mnt/nfs',
+                          'mountPropagation': 'HostToContainer',
                           'readOnly': True
                       },
                   ]
@@ -305,7 +295,7 @@ maintainDumpsNfs:
   enabled: false
   image:
     name: quay.io/wikimedia-paws-prod/maintain-dumps-nfs
-    tag: pr-1 # maintain-dumps-nfs tag managed by github actions
+    tag: pr-531 # maintain-dumps-nfs tag managed by github actions
     template: "{{ .Values.maintainDumpsNfs.image.name }}:{{ .Values.maintainDumpsNfs.image.tag }}"
   server: dumps-nfs.wikimedia.org
   compatSymlinks:

--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -295,7 +295,7 @@ maintainDumpsNfs:
   enabled: false
   image:
     name: quay.io/wikimedia-paws-prod/maintain-dumps-nfs
-    tag: pr-531 # maintain-dumps-nfs tag managed by github actions
+    tag: pr-523 # maintain-dumps-nfs tag managed by github actions
     template: "{{ .Values.maintainDumpsNfs.image.name }}:{{ .Values.maintainDumpsNfs.image.tag }}"
   server: dumps-nfs.wikimedia.org
   compatSymlinks:


### PR DESCRIPTION
Enable the `maintain-nfs-dumps` daemonset and switch mountpoints to be as described in #522.

Easiest deployment strategy I can think of is:
* merge + deploy
* test by spawning a new `singleuser` container.
  * Validate `dumps-nfs.w.o` is mounted at `/mnt/nfs/dumps`
  * Validate `/public/dumps/public` points to `/mnt/nfs/dumps`
  * Validate `/mnt/nfs/dumps-clouddumps*` point to `dumps`