### PR TITLE
Restore nbgitpuller, dropped as collateral of the JupyterLab 4 upgrade in #317

### DIFF
--- a/images/singleuser/requirements.txt
+++ b/images/singleuser/requirements.txt
@@ -41,6 +41,13 @@ wmpaws
 flask
 fastapi
 
+# One-click "open this notebook" links
+# (https://hub-paws.wmcloud.org/hub/user-redirect/git-pull?...)
+# >=1.2 is deliberate: 1.1.1 and earlier depend on notebook, which is how the
+# JupyterLab 4 upgrade in #317 ended up installing notebook 7. 1.2.0 dropped
+# that dependency.
+nbgitpuller>=1.2
+
 # mwpersistence has a dep which pulls in PyYAML 5.4.1, which has
 # packaging issues with Cython 3.0.0 (also present in PyYAML 6.0.0).
 # Pin a higher version.


### PR DESCRIPTION
## What

Re-adds `nbgitpuller>=1.2` to the singleuser image (one requirement line, plus a comment explaining the floor).

## Why

nbgitpuller was added in #66 (May 2021) so that `/hub/user-redirect/git-pull?repo=...&urlpath=...` links could pull a repo into a user's PAWS home and open a notebook in one click — the standard way to put an "open this example on PAWS" link on a wiki page.

## Why it was removed

Not for its own sake — it was collateral of the JupyterLab 4 upgrade in #317, which also dropped the `notebook` pin and left nbgitpuller 1.1.1's `notebook>=5.5.0` pulling in notebook 7. Full history, and why removing it was never necessary, in T434973.

Current behavior (verified 2026-08-13): clicking a git-pull link resolves through the hub, then 404s on the user server, e.g.

```
https://hub-paws.wmcloud.org/user/<name>/git-pull?repo=...  →  404
```

because nothing in the image registers the `git-pull` handler. Confirmed absent from `images/singleuser/{Dockerfile,requirements.txt,install-extensions}` on main.

## Compatibility

nbgitpuller 1.2.0 (2023-08-07) dropped the `notebook` dependency, and 1.3.0 declares only `jupyter_server>=1.10.1` and `tornado`. It ships no JupyterLab prebuilt extension in any version — it is a `jupyter_server` extension — so there is no JupyterLab version coupling; the image's jupyterlab 4.4.0 pulls `jupyter_server>=2.4`, well above the floor. The image no longer installs `notebook` at all (that pin went in #324).

The requirement is written `>=1.2` so that no future resolution can land on ≤1.1.1 and reintroduce the `notebook` dependency that caused the 2023 breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Manually reviewed by @audiodude 

