### PR TITLE
Restore nbgitpuller, dropped as collateral of the JupyterLab 4 upgrade

### DIFF
--- a/images/singleuser/requirements.txt
+++ b/images/singleuser/requirements.txt
@@ -41,6 +41,13 @@ wmpaws
 flask
 fastapi
 
+# One-click "open this notebook" links
+# (https://hub-paws.wmcloud.org/hub/user-redirect/git-pull?...)
+# >=1.2 is deliberate: 1.1.1 and earlier depend on notebook, which is how the
+# JupyterLab 4 upgrade in #317 ended up installing notebook 7. 1.2.0 dropped
+# that dependency.
+nbgitpuller>=1.2
+
 # mwpersistence has a dep which pulls in PyYAML 5.4.1, which has
 # packaging issues with Cython 3.0.0 (also present in PyYAML 6.0.0).
 # Pin a higher version.

--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -257,7 +257,7 @@ jupyterhub:
     fsGid: 52771
     image:
       name: quay.io/wikimedia-paws-prod/singleuser
-      tag: pr-529 # singleuser tag managed by github actions
+      tag: pr-530 # singleuser tag managed by github actions
       pullPolicy: Always
     memory:
       guarantee: 0.70G


### PR DESCRIPTION
This is a cherry-pick of #528 pushed to the main repo `toolforge/paws`, as PRs from forked repos cannot run the full CI pipeline, and do not update `values.yaml` with the right tag `pr-xxx`.

_____

nbgitpuller was added in #66 (May 2021) and dropped in #317 (Aug 2023), but not for its own sake. 1b99c87 upgraded JupyterLab 3.4.8 -> 4.0.3 and also removed the notebook==6.4.12 pin, which left nbgitpuller 1.1.1's notebook>=5.5.0 as the only requirement on notebook in the image, so pip resolved it to the newest release: notebook 7.0.1, in a JupyterLab 4 image. 47 minutes later 9d3969d2 re-pinned notebook==6.5.5 and commented out nbgitpuller in the same commit, alongside a test matrix noting that Lab 4 worked with notebook 6.5.5 and not with 7.0.1. A cleanup commit before merge deleted both the matrix and the disabled line, so the squashed result shows only an unexplained one-line deletion.

Restoring the pin was the fix on its own: pip does not upgrade a package that is already installed and already satisfies an unpinned requirement. The two changes went in together and were never separated, so nbgitpuller was removed alongside the thing that actually fixed it.

It is safe to bring back. nbgitpuller 1.2.0 (2023-08-07) dropped the notebook dependency; 1.3.0 declares only jupyter_server>=1.10.1 and tornado and ships no JupyterLab extension, and the image no longer installs notebook at all. Requiring >=1.2 keeps the 2023 failure mode unreachable.

Bug: T434973